### PR TITLE
[WIP] Feature: Manage/reorder lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.pem
 *.zip
 app/contentscript.js
+app/contentscript.js.map
 node_modules/

--- a/app/main.css
+++ b/app/main.css
@@ -1,3 +1,7 @@
+/*
+ * Sidebar
+ */
+
 .list-of-lists {
   margin: 10px -15px;
 }
@@ -48,6 +52,11 @@ ul.list-membership-container li {
   border-bottom-right-radius: 3px;
 }
 
+
+/*
+ * Profile hovercard
+ */
+
 .ProfileCardLists .list-membership-container {
   margin-bottom: 0;
   /* li are 37px each, 37*4 = 148 */
@@ -67,4 +76,51 @@ ul.list-membership-container li {
 
 .ProfileCardLists .list-membership-container li:last-child {
   border-bottom: 0;
+}
+
+
+/*
+ * Manage lists - /user/lists & /user/memberships
+ */
+
+.Grid-cell[data-test-selector="ProfileTimelineList"] {
+  background: #fff;
+  border-left: 1px solid #e1e8ed;
+  border-right: 1px solid #e1e8ed;
+  background-clip: padding-box;
+  margin-bottom: 0 !important;
+}
+
+.Grid-cell .ProfileListItem {
+  margin: 0;
+  padding: 10px 15px;
+}
+
+.drag-ready .ProfileListItem {
+  cursor: grab;
+  cursor: -webkit-grab;
+}
+
+/* below from dragula; don't want to setup a css build task yet... */
+.gu-mirror {
+  position: fixed !important;
+  margin: 0 !important;
+  z-index: 9999 !important;
+  opacity: 0.8;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=80)";
+  filter: alpha(opacity=80);
+}
+.gu-hide {
+  display: none !important;
+}
+.gu-unselectable {
+  -webkit-user-select: none !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+  user-select: none !important;
+}
+.gu-transit {
+  opacity: 0.2;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
+  filter: alpha(opacity=20);
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -9,7 +9,8 @@
   "icons": { "128": "icon128.png" },
 
   "permissions": [
-    "https://twitter.com/*"
+    "https://twitter.com/*",
+    "storage"
   ],
   "content_scripts": [
     {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,12 @@
   "devDependencies": {
     "babel-preset-es2015-rollup": "^1.1.1",
     "node-zip": "^1.1.1",
-    "rollup": "^0.25.2",
-    "rollup-plugin-babel": "^2.3.9"
+    "rollup": "^0.25.4",
+    "rollup-plugin-babel": "^2.4.0",
+    "rollup-plugin-commonjs": "^2.2.1",
+    "rollup-plugin-node-resolve": "^1.5.0"
+  },
+  "dependencies": {
+    "dragula": "^3.6.8"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,18 @@
 import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs'
+import nodeResolve from 'rollup-plugin-node-resolve'
 
 export default {
   entry: 'src/contentscript.js',
   format: 'cjs',
+  sourceMap: true,
   plugins: [
+    nodeResolve({
+      jsnext: true,
+      main: true,
+      browser: true
+    }),
+    commonjs(),
     babel({
       presets: ['es2015-rollup']
     })

--- a/src/contentscript.js
+++ b/src/contentscript.js
@@ -1,9 +1,11 @@
 import {setupSidebar} from './sidebar.js';
 import {setupProfileCard} from './profile-card.js';
+import {setupManage} from './manage.js'
 
 function setup(pageChange) {
   setupSidebar(pageChange);
   setupProfileCard(pageChange);
+  setupManage(pageChange);
 }
 
 function init() {

--- a/src/manage.js
+++ b/src/manage.js
@@ -1,17 +1,84 @@
+import {getUsername} from './twitter.js';
+import * as storage from './storage.js';
+
 import dragula from 'dragula';
+
+function reorderFromStorage() {
+  var container = document.querySelector('.GridTimeline-items')
+  var elements = container.querySelectorAll('.Grid');
+
+  while (container.lastChild) {
+    container.removeChild(container.lastChild);
+  }
+
+  storage.get("lists").then(({lists}) => {
+    var sorted = [...elements]
+      .map((element) => { // give each element a listIndex if we know it's index
+        var {userId, listId} = element.querySelector('.ProfileListItem').dataset;
+        var index = lists.findIndex((list) => list.userId === userId && list.listId === listId);
+        if (index != -1) {
+          element.dataset.listIndex = index;
+        }
+        return element;
+      })
+      .sort((a, b) => { // sort the elements
+        var aIndex = a.dataset.listIndex;
+        var bIndex = b.dataset.listIndex;
+
+        if (!aIndex && !bIndex) return 0;   // neither defined
+        if (!!aIndex && !bIndex) return 1;  // indexed on top, new on bottom
+        if (!aIndex && !!bIndex) return -1;
+
+        if (aIndex < bIndex) return -1;
+        if (aIndex > bIndex) return 1;
+
+        return 0;
+      })
+      .forEach((element) => { // re-add to container
+        container.appendChild(element);
+      });
+  });
+}
+
+function getLists() {
+  return [...document.querySelectorAll('.ProfileListItem')]
+    .map(({dataset}) => {
+      return {
+        userId: dataset.userId,
+        listId: dataset.listId
+      }
+    });
+}
+
+function updateStorage(lists) {
+  storage.set({lists})
+}
+
+function onDrop() {
+  var lists = getLists();
+  updateStorage(lists);
+}
+
+function setupDragulaHandlers(drake) {
+  drake.on('drop', onDrop);
+}
 
 function setupDragula() {
   var listContainer = document.querySelector('.GridTimeline-items');
   var options = {
     revertOnSpill: true
   };
-  dragula([listContainer], options);
+  var drake = dragula([listContainer], options);
   listContainer.classList.add('drag-ready');
+  return drake;
 }
 
 export function setupManage() {
-  if (!window.location.pathname.endsWith('/lists')) {
+  if (window.location.pathname !== `/${getUsername()}/lists`) {
+    // must be on own lists page for drag&drop
     return;
   }
-  setupDragula();
+  var drake = setupDragula();
+  setupDragulaHandlers(drake);
+  reorderFromStorage();
 }

--- a/src/manage.js
+++ b/src/manage.js
@@ -1,0 +1,17 @@
+import dragula from 'dragula';
+
+function setupDragula() {
+  var listContainer = document.querySelector('.GridTimeline-items');
+  var options = {
+    revertOnSpill: true
+  };
+  dragula([listContainer], options);
+  listContainer.classList.add('drag-ready');
+}
+
+export function setupManage() {
+  if (!window.location.pathname.endsWith('/lists')) {
+    return;
+  }
+  setupDragula();
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,23 @@
+export function get(key) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.sync.get(key, (items) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(items);
+    });
+  });
+}
+
+export function set(items) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.sync.set(items, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve();
+    })
+  })
+}

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -7,6 +7,10 @@ export function getUsername() {
   return user.dataset.screenName;
 }
 
+export function getUserId() {
+  return getInitData().userId;
+}
+
 function getInitData() {
   return JSON.parse(document.querySelector("#init-data").value);
 }


### PR DESCRIPTION
A very common request is the ability to reorder lists. Most straight-forward way is to use drag&drop. 

Thinking the best place to do this initially is the `/user/lists` page (linked from top-menu > My Lists, and also via profile), which needs some styling.

Under consideration:
- Add drag/drop on sidebar?
- Use drag handle on side?

Todo:
- [ ] Restyle /user/lists page
- [x] Add drag&drop functionality
- [x] Persistence (+ Chrome sync!)
- [x] Sort sidebar and profile cards
- [ ] Deal with infinite scrolling (`.has-more-items`)